### PR TITLE
fix: move pnpm install step to before the build process in release wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,10 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
+      - run: pnpm install --frozen-lockfile
+      
       - name: Build package
         run: pnpm build
-
-      - run: pnpm install --frozen-lockfile
 
       - name: Release with semantic-release
         run: pnpm release


### PR DESCRIPTION
This pull request makes a minor adjustment to the release workflow configuration. The main change is reordering the `pnpm install --frozen-lockfile` step so that dependencies are installed before building the package, ensuring the build process has all required dependencies.

* Release workflow update:
  * Moved the `pnpm install --frozen-lockfile` step to occur before the package build step in `.github/workflows/release.yml`, ensuring dependencies are installed prior to building.