### PR TITLE
Update release rules for semantic versioning

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,22 @@
     "@semantic-release/commit-analyzer",
     {
       "preset": "conventionalcommits",
-      "releaseRules": [{ "type": "chore", "release": "patch" }]
+      "releaseRules": [
+        { "type": "feat", "release": "minor" },
+        { "type": "fix", "release": "patch" },
+        { "type": "perf", "release": "patch" },
+
+        { "type": "refactor", "release": "patch" },
+        { "type": "build", "release": "patch" },
+        { "type": "ci", "release": "patch" },
+
+        { "type": "chore", "release": "patch" },
+        { "type": "docs", "release": false },
+        { "type": "style", "release": false },
+        { "type": "test", "release": false },
+
+        { "breaking": true, "release": "major" }
+      ]
     },
     "@semantic-release/release-notes-generator",
     [


### PR DESCRIPTION
This pull request updates the release rules in `.releaserc.json` to provide more granular and conventional mapping between commit types and release versions. The main change is expanding the `releaseRules` to cover all major Conventional Commits types, ensuring that releases are triggered appropriately based on the nature of changes.

Release automation improvements:

* Expanded the `releaseRules` array to handle multiple commit types, mapping `feat` to minor releases, `fix`, `perf`, `refactor`, `build`, and `ci` to patch releases, and disabling releases for `docs`, `style`, and `test` commit types. Breaking changes now trigger a major release.