### PR TITLE
pref(release): patch release rules and update deps.

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,20 +11,17 @@
     {
       "preset": "conventionalcommits",
       "releaseRules": [
+        { "breaking": true, "release": "major" },
         { "type": "feat", "release": "minor" },
         { "type": "fix", "release": "patch" },
         { "type": "perf", "release": "patch" },
 
-        { "type": "refactor", "release": "patch" },
-        { "type": "build", "release": "patch" },
-        { "type": "ci", "release": "patch" },
-
-        { "type": "chore", "release": "patch" },
+        { "type": "refactor", "release": false },
+        { "type": "build", "release": false },
+        { "type": "ci", "release": false },
+        { "type": "chore", "release": false },
         { "type": "docs", "release": false },
-        { "type": "style", "release": false },
-        { "type": "test", "release": false },
-
-        { "breaking": true, "release": "major" }
+        { "type": "test", "release": false }
       ]
     },
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
- patch semantic release commit analyzer to release on ci/cd commands.
- 
This pull request updates the release rules in `.releaserc.json` to better control which commit types trigger a release. The main changes are to prevent non-functional commit types from creating releases, and to ensure breaking changes always trigger a major release.

Release rules changes:

* Added an explicit rule so that any commit marked as breaking will always trigger a major release.
* Changed the release behavior for `refactor`, `build`, `ci`, and `chore` commit types so they no longer trigger a release, instead of previously triggering a patch release.
* Cleaned up redundant or duplicate rules for breaking changes and style/test commit types.