### PR TITLE
Dev

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -66,7 +66,7 @@
       "recommended": false,
       "style": {
         "useImportType": {
-          "level": "on",
+          "level": "off",
           "options": {
             "style": "inlineType"
           }

--- a/src/components/HeadlessSearchInput.tsx
+++ b/src/components/HeadlessSearchInput.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import type React from 'react'
-import { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { type HeadlessSearchInputProps } from '../lib/headlessSearch.js'
 import { type SearchResult } from '../types.js'

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import type React from 'react'
-import { createContext, use } from 'react'
+import React, { createContext, use } from 'react'
 
 import { useThemeConfig } from './themes/hooks.js'
 import { type ThemeConfig, type ThemeContextValue } from './themes/types.js'


### PR DESCRIPTION
This pull request makes minor adjustments to import statements in the codebase and updates a configuration setting in `biome.json`. The main changes are:

**Configuration changes:**

* Turned off the `useImportType` style rule in `biome.json`, which previously enforced the use of `import type` for TypeScript type imports.

**Code import adjustments:**

* Updated import statements in `HeadlessSearchInput.tsx` and `ThemeProvider.tsx` to use `import React, { ... }` instead of separate `import type React` and value imports. This change ensures compatibility with certain linting and build tools and aligns with the updated configuration. [[1]](diffhunk://#diff-bf8ba033e5aefc074748b9029c5e46aed095ace97903575f7c1cf7ad7508a9bfL3-R3) [[2]](diffhunk://#diff-248068ec05f19c3cd7bfd14f5ea57ed9f60d98f9e973761c5bf4f80b5f929d4aL3-R3)