### PR TITLE
chore: enhance biome.json linter rules by adding accessibility

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -69,10 +69,15 @@
     "rules": {
       "preset": "recommended",
       "a11y": {
-        "noSvgWithoutTitle": "off"
+        "noSvgWithoutTitle": "off",
+        "useMediaCaption": "off",
+        "useSemanticElements": "off"
       },
       "correctness": {
         "noUnusedImports": "off"
+      },
+      "suspicious": {
+        "noImplicitAnyLet": "off"
       },
       "style": {
         "useImportType": {


### PR DESCRIPTION
This pull request updates the `biome.json` configuration to adjust accessibility and type safety linting rules. The main changes involve turning off several accessibility rules and disabling a type safety rule.

Accessibility rules:

* Turned off the `useMediaCaption` rule, which enforces captions for media elements.
* Turned off the `useSemanticElements` rule, which enforces the use of semantic HTML elements.

Type safety rules:

* Turned off the `noImplicitAnyLet` rule, which prevents implicitly `any`-typed `let` variables.